### PR TITLE
Add variable rebinning

### DIFF
--- a/dctools/__init__.py
+++ b/dctools/__init__.py
@@ -382,7 +382,7 @@ class datagroup:
             
             bh_hist:hist.Hist = _hist['hist'][{
                 "channel" : self.channel,
-                self.observable : hist.rebin(self.rebin)
+                self.observable : hist.rebin(deepcopy(self.rebin)) if isinstance(self.rebin, int) else hist.rebin(groups=deepcopy(self.rebin))
             }]
             _scale = 1 
             if ptype.lower() != "data": 


### PR DESCRIPTION
There's a bug in boost-histogram or histogram… that's modifying the rebin list in-place, hence the need for a deepcopy of the self.rebin variable. This is probably adding 1s to the start/end for the overflow bins if they're present.